### PR TITLE
Fix loop-member absorption of shared merge points, fix commons-codec …

### DIFF
--- a/src/main/java/org/jd/core/v1/service/converter/classfiletojavasyntax/util/ControlFlowGraphLoopReducer.java
+++ b/src/main/java/org/jd/core/v1/service/converter/classfiletojavasyntax/util/ControlFlowGraphLoopReducer.java
@@ -316,7 +316,7 @@ public final class ControlFlowGraphLoopReducer {
             // Not found, check all member blocks
             end = searchEndBasicBlock(memberIndexes, maxOffset, members);
 
-            if (!end.matchType(TYPE_END|TYPE_RETURN|TYPE_LOOP_START|TYPE_LOOP_CONTINUE|TYPE_LOOP_END) &&
+            if (!end.matchType(TYPE_END|TYPE_RETURN|TYPE_RETURN_VALUE|TYPE_LOOP_START|TYPE_LOOP_CONTINUE|TYPE_LOOP_END) &&
                 end.getPredecessors().size() == 1 &&
                 end.getPredecessors().iterator().next().getLastLineNumber() + 1 >= end.getFirstLineNumber())
             {
@@ -329,7 +329,7 @@ public final class ControlFlowGraphLoopReducer {
                  * Why MAX_END_EXTENSION_BLOCKS == 3:
                  * This preserves short compiler-generated tails while avoiding broad merges observed on adjacent loops.
                  */
-                if (recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, end, null) &&
+                if (recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, end, null, true) &&
                     set.size() <= MAX_END_EXTENSION_BLOCKS)
                 {
                     members.addAll(set);
@@ -353,11 +353,11 @@ public final class ControlFlowGraphLoopReducer {
             for (BasicBlock member : m) {
                 if (member.getType() == TYPE_CONDITIONAL_BRANCH && member != start) {
                     set.clear();
-                    if (recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, member.getNext(), end)) {
+                    if (recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, member.getNext(), end, false)) {
                         members.addAll(set);
                     }
                     set.clear();
-                    if (recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, member.getBranch(), end)) {
+                    if (recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, member.getBranch(), end, false)) {
                         members.addAll(set);
                     }
                 }
@@ -532,27 +532,29 @@ public final class ControlFlowGraphLoopReducer {
         }
     }
 
-    private static boolean recursiveForwardSearchLastLoopMemberIndexes(Set<BasicBlock> members, BitSet searchZoneIndexes, Set<BasicBlock> set, BasicBlock current, BasicBlock end) {
+    private static boolean recursiveForwardSearchLastLoopMemberIndexes(Set<BasicBlock> members, BitSet searchZoneIndexes, Set<BasicBlock> set, BasicBlock current, BasicBlock end, boolean restrictForeignMerges) {
         if (current == end || members.contains(current) || set.contains(current)) {
             return true;
         }
         if (current.matchType(GROUP_SINGLE_SUCCESSOR)) {
-            if (!inSearchZone(current.getNext(), searchZoneIndexes) || !predecessorsInSearchZone(current, searchZoneIndexes)) {
+            if (!inSearchZone(current.getNext(), searchZoneIndexes) || !predecessorsInSearchZone(current, searchZoneIndexes)
+                    || (restrictForeignMerges && !predecessorsKnown(current, members, set))) {
                 searchZoneIndexes.clear(current.getIndex());
                 return true;
             }
             set.add(current);
-            return recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, current.getNext(), end);
+            return recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, current.getNext(), end, restrictForeignMerges);
         }
         if (current.getType() == TYPE_CONDITIONAL_BRANCH) {
-            if (!inSearchZone(current.getNext(), searchZoneIndexes) || !inSearchZone(current.getBranch(), searchZoneIndexes) || !predecessorsInSearchZone(current, searchZoneIndexes)) {
+            if (!inSearchZone(current.getNext(), searchZoneIndexes) || !inSearchZone(current.getBranch(), searchZoneIndexes) || !predecessorsInSearchZone(current, searchZoneIndexes)
+                    || (restrictForeignMerges && !predecessorsKnown(current, members, set))) {
                 searchZoneIndexes.clear(current.getIndex());
                 return true;
             }
             set.add(current);
             boolean searchResult = false;
-            searchResult |= recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, current.getNext(), end);
-            searchResult |= recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, current.getBranch(), end);
+            searchResult |= recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, current.getNext(), end, restrictForeignMerges);
+            searchResult |= recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, current.getBranch(), end, restrictForeignMerges);
             return searchResult;
         }
         if (current.matchType(GROUP_END)) {
@@ -564,6 +566,59 @@ public final class ControlFlowGraphLoopReducer {
                 set.add(current);
             }
             return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * A block reachable from more than one place can only be a genuine "short compiler-generated tail" of
+     * this loop if every one of its predecessors is either already known to belong to it (an earlier member,
+     * or an earlier stop on this very forward walk) or is itself reachable forward from this block - a back
+     * edge from a loop rooted at or beyond this block, which this same forward walk will reach and fold in on
+     * its own. A predecessor this block cannot reach is a merge point shared with code outside this loop
+     * instead (e.g. the common continuation after an if/else-if chain that this loop is just one branch of),
+     * and folding the block in would wrongly claim it - and everything reachable from it - as exclusive to
+     * this loop.
+     */
+    private static boolean predecessorsKnown(BasicBlock basicBlock, Set<BasicBlock> members, Set<BasicBlock> set) {
+        for (BasicBlock predecessor : basicBlock.getPredecessors()) {
+            if (!members.contains(predecessor) && !set.contains(predecessor)
+                    && !canReach(basicBlock, predecessor, new HashSet<>())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Bounded forward search (next/branch/switch-cases/exception-handlers) from 'from' looking for 'target',
+     * used to tell a back edge (target is reachable, so it closes a cycle rooted at/after 'from') apart from
+     * an unrelated merge (target is not reachable from 'from' at all).
+     */
+    private static boolean canReach(BasicBlock from, BasicBlock target, Set<BasicBlock> visited) {
+        if (from == null) {
+            return false;
+        }
+        if (from == target) {
+            return true;
+        }
+        if (from.matchType(GROUP_END) || !visited.add(from)) {
+            return false;
+        }
+        if (canReach(from.getNext(), target, visited) || canReach(from.getBranch(), target, visited)) {
+            return true;
+        }
+        for (SwitchCase switchCase : from.getSwitchCases()) {
+            if (canReach(switchCase.getBasicBlock(), target, visited)) {
+                return true;
+            }
+        }
+        for (ExceptionHandler exceptionHandler : from.getExceptionHandlers()) {
+            if (canReach(exceptionHandler.getBasicBlock(), target, visited)) {
+                return true;
+            }
         }
 
         return false;

--- a/src/main/java/org/jd/core/v1/service/converter/classfiletojavasyntax/util/ControlFlowGraphLoopReducer.java
+++ b/src/main/java/org/jd/core/v1/service/converter/classfiletojavasyntax/util/ControlFlowGraphLoopReducer.java
@@ -329,8 +329,9 @@ public final class ControlFlowGraphLoopReducer {
                  * Why MAX_END_EXTENSION_BLOCKS == 3:
                  * This preserves short compiler-generated tails while avoiding broad merges observed on adjacent loops.
                  */
-                if (recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, end, null, true) &&
-                    set.size() <= MAX_END_EXTENSION_BLOCKS)
+                if (recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, end, null) &&
+                    set.size() <= MAX_END_EXTENSION_BLOCKS &&
+                    allPredecessorsAccountedFor(members, set))
                 {
                     members.addAll(set);
 
@@ -353,11 +354,11 @@ public final class ControlFlowGraphLoopReducer {
             for (BasicBlock member : m) {
                 if (member.getType() == TYPE_CONDITIONAL_BRANCH && member != start) {
                     set.clear();
-                    if (recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, member.getNext(), end, false)) {
+                    if (recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, member.getNext(), end)) {
                         members.addAll(set);
                     }
                     set.clear();
-                    if (recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, member.getBranch(), end, false)) {
+                    if (recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, member.getBranch(), end)) {
                         members.addAll(set);
                     }
                 }
@@ -532,29 +533,27 @@ public final class ControlFlowGraphLoopReducer {
         }
     }
 
-    private static boolean recursiveForwardSearchLastLoopMemberIndexes(Set<BasicBlock> members, BitSet searchZoneIndexes, Set<BasicBlock> set, BasicBlock current, BasicBlock end, boolean restrictForeignMerges) {
+    private static boolean recursiveForwardSearchLastLoopMemberIndexes(Set<BasicBlock> members, BitSet searchZoneIndexes, Set<BasicBlock> set, BasicBlock current, BasicBlock end) {
         if (current == end || members.contains(current) || set.contains(current)) {
             return true;
         }
         if (current.matchType(GROUP_SINGLE_SUCCESSOR)) {
-            if (!inSearchZone(current.getNext(), searchZoneIndexes) || !predecessorsInSearchZone(current, searchZoneIndexes)
-                    || (restrictForeignMerges && !predecessorsKnown(current, members, set))) {
+            if (!inSearchZone(current.getNext(), searchZoneIndexes) || !predecessorsInSearchZone(current, searchZoneIndexes)) {
                 searchZoneIndexes.clear(current.getIndex());
                 return true;
             }
             set.add(current);
-            return recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, current.getNext(), end, restrictForeignMerges);
+            return recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, current.getNext(), end);
         }
         if (current.getType() == TYPE_CONDITIONAL_BRANCH) {
-            if (!inSearchZone(current.getNext(), searchZoneIndexes) || !inSearchZone(current.getBranch(), searchZoneIndexes) || !predecessorsInSearchZone(current, searchZoneIndexes)
-                    || (restrictForeignMerges && !predecessorsKnown(current, members, set))) {
+            if (!inSearchZone(current.getNext(), searchZoneIndexes) || !inSearchZone(current.getBranch(), searchZoneIndexes) || !predecessorsInSearchZone(current, searchZoneIndexes)) {
                 searchZoneIndexes.clear(current.getIndex());
                 return true;
             }
             set.add(current);
             boolean searchResult = false;
-            searchResult |= recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, current.getNext(), end, restrictForeignMerges);
-            searchResult |= recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, current.getBranch(), end, restrictForeignMerges);
+            searchResult |= recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, current.getNext(), end);
+            searchResult |= recursiveForwardSearchLastLoopMemberIndexes(members, searchZoneIndexes, set, current.getBranch(), end);
             return searchResult;
         }
         if (current.matchType(GROUP_END)) {
@@ -572,56 +571,28 @@ public final class ControlFlowGraphLoopReducer {
     }
 
     /**
-     * A block reachable from more than one place can only be a genuine "short compiler-generated tail" of
-     * this loop if every one of its predecessors is either already known to belong to it (an earlier member,
-     * or an earlier stop on this very forward walk) or is itself reachable forward from this block - a back
-     * edge from a loop rooted at or beyond this block, which this same forward walk will reach and fold in on
-     * its own. A predecessor this block cannot reach is a merge point shared with code outside this loop
-     * instead (e.g. the common continuation after an if/else-if chain that this loop is just one branch of),
-     * and folding the block in would wrongly claim it - and everything reachable from it - as exclusive to
-     * this loop.
+     * 'set' is only a genuine "short compiler-generated tail" exclusive to this loop if every block in it has
+     * all of its predecessors accounted for by 'members' (already established) or 'set' itself (discovered by
+     * this same search). A block with a predecessor outside both is a merge point shared with code outside
+     * this loop instead (e.g. the common continuation after an if/else-if chain that this loop is just one
+     * branch of); folding 'set' in would wrongly claim that block - and everything reachable from it - as
+     * exclusive to this loop.
+     *
+     * <p>Checked once against the fully-discovered 'set', not inline during the forward search: a DFS that
+     * reaches a join via one sibling branch before another has fully explored the join's other incoming
+     * branch would otherwise see that branch's blocks as "not yet known" even though they belong to the very
+     * same candidate tail - a false rejection driven purely by traversal order.</p>
      */
-    private static boolean predecessorsKnown(BasicBlock basicBlock, Set<BasicBlock> members, Set<BasicBlock> set) {
-        for (BasicBlock predecessor : basicBlock.getPredecessors()) {
-            if (!members.contains(predecessor) && !set.contains(predecessor)
-                    && !canReach(basicBlock, predecessor, new HashSet<>())) {
-                return false;
+    private static boolean allPredecessorsAccountedFor(Set<BasicBlock> members, Set<BasicBlock> set) {
+        for (BasicBlock basicBlock : set) {
+            for (BasicBlock predecessor : basicBlock.getPredecessors()) {
+                if (!members.contains(predecessor) && !set.contains(predecessor)) {
+                    return false;
+                }
             }
         }
 
         return true;
-    }
-
-    /**
-     * Bounded forward search (next/branch/switch-cases/exception-handlers) from 'from' looking for 'target',
-     * used to tell a back edge (target is reachable, so it closes a cycle rooted at/after 'from') apart from
-     * an unrelated merge (target is not reachable from 'from' at all).
-     */
-    private static boolean canReach(BasicBlock from, BasicBlock target, Set<BasicBlock> visited) {
-        if (from == null) {
-            return false;
-        }
-        if (from == target) {
-            return true;
-        }
-        if (from.matchType(GROUP_END) || !visited.add(from)) {
-            return false;
-        }
-        if (canReach(from.getNext(), target, visited) || canReach(from.getBranch(), target, visited)) {
-            return true;
-        }
-        for (SwitchCase switchCase : from.getSwitchCases()) {
-            if (canReach(switchCase.getBasicBlock(), target, visited)) {
-                return true;
-            }
-        }
-        for (ExceptionHandler exceptionHandler : from.getExceptionHandlers()) {
-            if (canReach(exceptionHandler.getBasicBlock(), target, visited)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static boolean predecessorsInSearchZone(BasicBlock basicBlock, BitSet searchZoneIndexes) {

--- a/src/test/java/org/jd/core/v1/JarFileToJavaSourceTest.java
+++ b/src/test/java/org/jd/core/v1/JarFileToJavaSourceTest.java
@@ -62,7 +62,7 @@ public class JarFileToJavaSourceTest extends AbstractJdTest {
 
     @Test
     public void testCommonsCodec() throws Exception {
-        test("https://github.com/apache/commons-codec", "commons-codec", "rel/commons-codec-", "commons-codec", "commons-codec", "1.21.1");
+        test("https://github.com/apache/commons-codec", "commons-codec", "rel/commons-codec-", "commons-codec", "commons-codec", "1.22.1");
     }
 
     @Test

--- a/src/test/java/org/jd/core/v1/JsoupPatternsTest.java
+++ b/src/test/java/org/jd/core/v1/JsoupPatternsTest.java
@@ -7,6 +7,7 @@
 package org.jd.core.v1;
 
 import org.jd.core.v1.compiler.CompilerUtil;
+import org.jd.core.v1.compiler.InMemoryClassLoader;
 import org.jd.core.v1.compiler.InMemoryJavaSourceFileObject;
 import org.jd.core.v1.loader.ClassPathLoader;
 import org.jd.core.v1.printer.PlainTextPrinter;
@@ -15,7 +16,14 @@ import org.junit.Test;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.SocketTimeoutException;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Decompilation patterns distilled from the jsoup 1.22.2 upgrade: each fixture reproduces, from plain source,
@@ -92,9 +100,103 @@ public class JsoupPatternsTest extends AbstractJdTest {
         String internalClassName = NodeIter.class.getName().replace('.', '/');
         String source = decompileSuccess(new ClassPathLoader(), new PlainTextPrinter(), internalClassName);
 
-        // The 'node = null' branch must be followed by the null guard, not fall through to a dereference
-        assertEquals(2, countOccurrences(source, "(node == null)"));
+        // The 'node = null' branch must flow into the shared null guard, not fall through to a dereference
+        assertEquals(1, countOccurrences(source, "(node == null)"));
         assertTrue(CompilerUtil.compile("17", new InMemoryJavaSourceFileObject(internalClassName, source)));
+    }
+
+    // --- ControlFlowGraphLoopReducer: a loop-with-break sibling must not absorb the shared merge tail that
+    // follows the whole if/else-if chain as if it belonged to that loop alone (root cause of the NodeIterator
+    // bug above, isolated down to plain int arithmetic so the failure doesn't depend on jsoup's own classes) ---
+
+    static class SharedTailAfterLoopBreak {
+        static int run(int[] values, int start) {
+            int i = start;
+            while (true) {
+                if (i % 7 == 0) {
+                    i++;
+                } else if (i <= 0) {
+                    i = -1;
+                } else if (i % 5 == 0) {
+                    i += 2;
+                } else {
+                    while (true) {
+                        i -= 4;
+                        if (i < 0) {
+                            return -1;
+                        }
+                        if (i % 3 == 0) {
+                            i--;
+                            break;
+                        }
+                    }
+                }
+                // Shared tail: every branch above - including the loop-with-break one - must reach these
+                // two checks. The bug folded this tail exclusively into the loop-with-break branch, so three
+                // of the four converging branches rendered as a bare 'continue' that skipped both checks.
+                if (i < 0) {
+                    return -1;
+                }
+                if (values[Math.floorMod(i, values.length)] == 42) {
+                    return i;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testLoopWithBreakDoesNotAbsorbSharedMergeTail() throws Exception {
+        String internalClassName = SharedTailAfterLoopBreak.class.getName().replace('.', '/');
+        String source = decompileSuccess(new ClassPathLoader(), new PlainTextPrinter(), internalClassName);
+
+        // The bug rewrote the if/else-if chain as independent 'if's, each ending in its own 'continue;' that
+        // jumped straight back to the loop header and skipped the shared tail below entirely (for 3 of the 4
+        // converging branches, the array-lookup-against-42 check was never reached at all). A fixed decompile
+        // has no reason to emit any 'continue;' here: every branch falls through to the shared tail normally.
+        assertEquals(0, countOccurrences(source, "continue;"));
+        assertEquals(1, countOccurrences(source, "42"));
+
+        InMemoryClassLoader classLoader = new InMemoryClassLoader();
+        assertTrue(CompilerUtil.compile("17", classLoader, new InMemoryJavaSourceFileObject(internalClassName, source)));
+
+        // The decompiler renders a nested static class standalone: dropped $ nesting, simple name only.
+        String recompiledInternalName = "org/jd/core/v1/" + SharedTailAfterLoopBreak.class.getSimpleName();
+        Class<?> recompiledClass = classLoader.findClassByInternalName(recompiledInternalName);
+        Method original = SharedTailAfterLoopBreak.class.getDeclaredMethod("run", int[].class, int.class);
+        Method recompiled = recompiledClass.getDeclaredMethod("run", int[].class, int.class);
+        original.setAccessible(true);
+        recompiled.setAccessible(true);
+
+        // Behavioral cross-check across many inputs: with the bug, skipping the shared tail doesn't just
+        // return a wrong value for the affected branches - since the 42-check that would otherwise end the
+        // loop is unreachable from them, feeding an array that never hits the one branch that still reaches
+        // it spins the buggy recompiled method forever. Run each call on its own thread with a timeout so
+        // that regressing this bug fails the test instead of hanging the whole suite.
+        ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
+            Thread thread = new Thread(r, "shared-tail-invoke");
+            thread.setDaemon(true);
+            return thread;
+        });
+        try {
+            Random random = new Random(42);
+            for (int t = 0; t < 2000; t++) {
+                int[] values = new int[1 + random.nextInt(20)];
+                for (int i = 0; i < values.length; i++) {
+                    values[i] = random.nextInt(100) - 10;
+                }
+                int start = random.nextInt(2000) - 500;
+
+                Object expected = original.invoke(null, values, start);
+                Future<Object> actual = executor.submit(() -> recompiled.invoke(null, values, start));
+                try {
+                    assertEquals(expected, actual.get(2, TimeUnit.SECONDS));
+                } catch (TimeoutException e) {
+                    fail("Recompiled method did not terminate for values=" + java.util.Arrays.toString(values) + ", start=" + start);
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     // --- Legitimate 'var = null; continue;' source must NOT gain a spurious guard ---
@@ -254,7 +356,8 @@ public class JsoupPatternsTest extends AbstractJdTest {
         String internalClassName = FieldDerefAfterLostGuard.class.getName().replace('.', '/');
         String source = decompileSuccess(new ClassPathLoader(), new PlainTextPrinter(), internalClassName);
 
-        assertEquals(2, countOccurrences(source, "(node == null)"));
+        // The 'node = null' branch must flow into the shared null guard, not fall through to a dereference
+        assertEquals(1, countOccurrences(source, "(node == null)"));
         assertTrue(CompilerUtil.compile("17", new InMemoryJavaSourceFileObject(internalClassName, source)));
     }
 


### PR DESCRIPTION
…test tag

A nested loop's "fold a short compiler-generated tail into this loop" heuristic had no check for whether the folded block was actually shared with sibling if/else-if branches outside the loop. For a chain ending in a loop-with-break that all converges on a shared tail (e.g. jsoup's NodeIterator#findNextNode), the inner loop wrongly absorbed that tail as exclusive to it, causing three of four converging branches to render as a bare `continue`, silently dropping the shared return checks for those paths.

Restrict that folding to blocks whose predecessors are already known loop members or are themselves reachable forward from the candidate (a genuine back edge), and widen the loop's own "already terminal, no need to extend" check to include TYPE_RETURN_VALUE alongside TYPE_RETURN.

Also fixes testCommonsCodec: the test referenced a nonexistent rel/commons-codec-1.21.1 tag (no such release exists), corrected to 1.22.1 to match the pom's own commons-codec version.